### PR TITLE
Optimize srgb decoding

### DIFF
--- a/srgb/srgb.go
+++ b/srgb/srgb.go
@@ -12,16 +12,48 @@ import (
 	"github.com/shogo82148/go-imaging/internal/parallels"
 )
 
+type nrgba64At interface {
+	image.Image
+	NRGBA64At(x, y int) color.NRGBA64
+}
+
+type nrgbaAt interface {
+	image.Image
+	NRGBAAt(x, y int) color.NRGBA
+}
+
+type rgba64At interface {
+	image.Image
+	RGBA64At(x, y int) color.RGBA64
+}
+
+type rgbaAt interface {
+	image.Image
+	RGBAAt(x, y int) color.RGBA
+}
+
 // Decode decodes an sRGB color encoded image to a linear color image.
 func Decode(img image.Image) *image.NRGBA64 {
+	switch img := img.(type) {
+	case nrgba64At:
+		return decodeNRGBA64(img)
+	case nrgbaAt:
+		return decodeNRGBA(img)
+	case rgba64At:
+		return decodeRGBA64(img)
+	case rgbaAt:
+		return decodeRGBA(img)
+	}
+	return decode(img)
+}
+
+func decodeNRGBA64(img nrgba64At) *image.NRGBA64 {
 	bounds := img.Bounds()
 	ret := image.NewNRGBA64(bounds)
 	parallels.Parallel(bounds.Min.Y, bounds.Max.Y, func(y int) {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			c := img.At(x, y)
-			c = color.NRGBA64Model.Convert(c)
-			rgba := c.(color.NRGBA64)
-			ret.SetRGBA64(x, y, color.RGBA64{
+			rgba := img.NRGBA64At(x, y)
+			ret.SetNRGBA64(x, y, color.NRGBA64{
 				R: encodedToLinearTable16[rgba.R],
 				G: encodedToLinearTable16[rgba.G],
 				B: encodedToLinearTable16[rgba.B],
@@ -31,6 +63,119 @@ func Decode(img image.Image) *image.NRGBA64 {
 	})
 
 	return ret
+}
+
+func decodeNRGBA(img nrgbaAt) *image.NRGBA64 {
+	bounds := img.Bounds()
+	ret := image.NewNRGBA64(bounds)
+	parallels.Parallel(bounds.Min.Y, bounds.Max.Y, func(y int) {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			rgba := img.NRGBAAt(x, y)
+			a := uint16(rgba.A)
+			a |= a << 8
+			ret.SetNRGBA64(x, y, color.NRGBA64{
+				R: encodedToLinearTable8[rgba.R],
+				G: encodedToLinearTable8[rgba.G],
+				B: encodedToLinearTable8[rgba.B],
+				A: a,
+			})
+		}
+	})
+
+	return ret
+}
+
+func decodeRGBA64(img rgba64At) *image.NRGBA64 {
+	bounds := img.Bounds()
+	ret := image.NewNRGBA64(bounds)
+	parallels.Parallel(bounds.Min.Y, bounds.Max.Y, func(y int) {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			rgba := img.RGBA64At(x, y)
+			ret.SetNRGBA64(x, y, convertRGBA64ToNRGBA64(rgba))
+		}
+	})
+
+	return ret
+}
+
+func decodeRGBA(img rgbaAt) *image.NRGBA64 {
+	bounds := img.Bounds()
+	ret := image.NewNRGBA64(bounds)
+	parallels.Parallel(bounds.Min.Y, bounds.Max.Y, func(y int) {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			rgba := img.RGBAAt(x, y)
+			ret.SetNRGBA64(x, y, convertRGBAToNRGBA64(rgba))
+		}
+	})
+
+	return ret
+}
+
+func decode(img image.Image) *image.NRGBA64 {
+	bounds := img.Bounds()
+	ret := image.NewNRGBA64(bounds)
+	parallels.Parallel(bounds.Min.Y, bounds.Max.Y, func(y int) {
+		for x := bounds.Min.X; x < bounds.Max.X; x++ {
+			c := img.At(x, y)
+			ret.SetNRGBA64(x, y, convertToNRGBA64(c))
+		}
+	})
+
+	return ret
+}
+
+func convertRGBA64ToNRGBA64(c color.RGBA64) color.NRGBA64 {
+	if c.A == 0xffff {
+		return color.NRGBA64{encodedToLinearTable16[c.R], encodedToLinearTable16[c.G], encodedToLinearTable16[c.B], 0xffff}
+	}
+	if c.A == 0 {
+		return color.NRGBA64{0, 0, 0, 0}
+	}
+	// Since Color.RGBA returns an alpha-premultiplied color, we should have r <= a && g <= a && b <= a.
+	r := (c.R * 0xffff) / c.A
+	g := (c.G * 0xffff) / c.A
+	b := (c.B * 0xffff) / c.A
+	return color.NRGBA64{encodedToLinearTable16[r], encodedToLinearTable16[g], encodedToLinearTable16[b], c.A}
+}
+
+func convertRGBAToNRGBA64(c color.RGBA) color.NRGBA64 {
+	if c.A == 0xff {
+		return color.NRGBA64{encodedToLinearTable8[c.R], encodedToLinearTable8[c.G], encodedToLinearTable8[c.B], 0xffff}
+	}
+	if c.A == 0 {
+		return color.NRGBA64{0, 0, 0, 0}
+	}
+
+	r := uint32(c.R)
+	g := uint32(c.G)
+	b := uint32(c.B)
+	a := uint32(c.A)
+
+	// Since Color.RGBA returns an alpha-premultiplied color, we should have r <= a && g <= a && b <= a.
+	r = (r * 0xffff) / a
+	g = (g * 0xffff) / a
+	b = (g * 0xffff) / a
+	a = a << 8
+	return color.NRGBA64{encodedToLinearTable16[r], encodedToLinearTable16[g], encodedToLinearTable16[b], uint16(a)}
+}
+
+func convertToNRGBA64(c color.Color) color.NRGBA64 {
+	if c, ok := c.(color.NRGBA64); ok {
+		return color.NRGBA64{encodedToLinearTable16[c.R], encodedToLinearTable16[c.G], encodedToLinearTable16[c.B], c.A}
+	}
+	r, g, b, a := c.RGBA()
+	if a == 0xffff {
+		return color.NRGBA64{encodedToLinearTable16[r], encodedToLinearTable16[g], encodedToLinearTable16[b], 0xffff}
+	}
+	if a == 0 {
+		return color.NRGBA64{0, 0, 0, 0}
+	}
+	// Since Color.RGBA returns an alpha-premultiplied color, we should have r <= a && g <= a && b <= a.
+	r = (r * 0xffff) / a
+	g = (g * 0xffff) / a
+	b = (b * 0xffff) / a
+	return color.NRGBA64{encodedToLinearTable16[r], encodedToLinearTable16[g], encodedToLinearTable16[b], uint16(a)}
+
 }
 
 // Encode encodes a linear color image to an sRGB color encoded image.

--- a/srgb/srgb_test.go
+++ b/srgb/srgb_test.go
@@ -24,7 +24,28 @@ func TestDecode(t *testing.T) {
 	}
 }
 
-func BenchmarkDecode(b *testing.B) {
+func BenchmarkDecode_RGBA(b *testing.B) {
+	input := image.NewRGBA(image.Rect(0, 0, 512, 512))
+	for i := 0; i < b.N; i++ {
+		Decode(input)
+	}
+}
+
+func BenchmarkDecode_RGBA64(b *testing.B) {
+	input := image.NewRGBA64(image.Rect(0, 0, 512, 512))
+	for i := 0; i < b.N; i++ {
+		Decode(input)
+	}
+}
+
+func BenchmarkDecode_NRGBA(b *testing.B) {
+	input := image.NewNRGBA(image.Rect(0, 0, 512, 512))
+	for i := 0; i < b.N; i++ {
+		Decode(input)
+	}
+}
+
+func BenchmarkDecode_NRGBA64(b *testing.B) {
 	input := image.NewNRGBA64(image.Rect(0, 0, 512, 512))
 	for i := 0; i < b.N; i++ {
 		Decode(input)


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-imaging/srgb
                  │   .old.txt   │              .new.txt               │
                  │    sec/op    │   sec/op     vs base                │
Decode_RGBA-10      2169.4µ ± 1%   489.2µ ± 1%  -77.45% (p=0.000 n=10)
Decode_RGBA64-10    1622.2µ ± 7%   448.6µ ± 1%  -72.35% (p=0.000 n=10)
Decode_NRGBA-10     2174.1µ ± 3%   486.1µ ± 1%  -77.64% (p=0.000 n=10)
Decode_NRGBA64-10   1297.5µ ± 1%   457.6µ ± 1%  -64.73% (p=0.000 n=10)
geomean              1.775m        470.0µ       -73.52%

                  │   .old.txt   │               .new.txt               │
                  │     B/op     │     B/op      vs base                │
Decode_RGBA-10      6.003Mi ± 0%   2.001Mi ± 0%  -66.66% (p=0.000 n=10)
Decode_RGBA64-10    6.004Mi ± 0%   2.001Mi ± 0%  -66.66% (p=0.000 n=10)
Decode_NRGBA-10     6.003Mi ± 0%   2.001Mi ± 0%  -66.66% (p=0.000 n=10)
Decode_NRGBA64-10   4.003Mi ± 0%   2.001Mi ± 0%  -50.00% (p=0.000 n=10)
geomean             5.425Mi        2.001Mi       -63.11%

                  │    .old.txt    │              .new.txt               │
                  │   allocs/op    │ allocs/op   vs base                 │
Decode_RGBA-10      524312.00 ± 0%   24.00 ± 0%  -100.00% (p=0.000 n=10)
Decode_RGBA64-10    524314.00 ± 0%   24.00 ± 0%  -100.00% (p=0.000 n=10)
Decode_NRGBA-10     524312.00 ± 0%   24.00 ± 0%  -100.00% (p=0.000 n=10)
Decode_NRGBA64-10   262168.00 ± 0%   24.00 ± 0%   -99.99% (p=0.000 n=10)
geomean                440.9k        24.00        -99.99%
```