### PR TITLE
pre-calculate lanczos weights

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
 .PHONY: examples
 examples:
 	go run ./internal/cmd/sample_gen examples
+
+.PHONY: golden
+golden:
+	go run ./resize/internal/cmd/golden ./resize/testdata

--- a/resize/lanczos.go
+++ b/resize/lanczos.go
@@ -4,7 +4,6 @@ import (
 	"image"
 	"math"
 
-	"github.com/shogo82148/float16"
 	"github.com/shogo82148/go-imaging/fp16"
 	"github.com/shogo82148/go-imaging/fp16/fp16color"
 	"github.com/shogo82148/go-imaging/internal/parallels"
@@ -21,6 +20,23 @@ func Lanczos2(dst, src *fp16.NRGBAh) {
 
 	tmp := fp16.NewNRGBAh(image.Rect(0, 0, dstDx, srcDy))
 
+	// pre-calculate lanczos weights
+	cache := make(map[float64]float64, 4*(dstDx+dstDy))
+	for x := 0; x < dstDx; x++ {
+		_, dx := scale(x, srcDx, dstDx)
+		cache[dx+1] = lanczos(dx+1, 2)
+		cache[dx+0] = lanczos(dx+0, 2)
+		cache[dx-1] = lanczos(dx-1, 2)
+		cache[dx-2] = lanczos(dx-2, 2)
+	}
+	for y := 0; y < dstDy; y++ {
+		_, dy := scale(y, srcDy, dstDy)
+		cache[dy+1] = lanczos(dy+1, 2)
+		cache[dy+0] = lanczos(dy+0, 2)
+		cache[dy-1] = lanczos(dy-1, 2)
+		cache[dy-2] = lanczos(dy-2, 2)
+	}
+
 	// resize horizontally
 	parallels.Parallel(0, srcDy, func(y int) {
 		for x := 0; x < dstDx; x++ {
@@ -31,10 +47,15 @@ func Lanczos2(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(src, srcBounds.Min.X+srcX+1, srcBounds.Min.Y+y)
 			c3 := nrgbhAt(src, srcBounds.Min.X+srcX+2, srcBounds.Min.Y+y)
 
-			c.R = lanczos2(c0.R, c1.R, c2.R, c3.R, dx)
-			c.G = lanczos2(c0.G, c1.G, c2.G, c3.G, dx)
-			c.B = lanczos2(c0.B, c1.B, c2.B, c3.B, dx)
-			c.A = lanczos2(c0.A, c1.A, c2.A, c3.A, dx)
+			a0 := cache[dx+1]
+			a1 := cache[dx+0]
+			a2 := cache[dx-1]
+			a3 := cache[dx-2]
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -49,10 +70,15 @@ func Lanczos2(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(tmp, x, srcY+1)
 			c3 := nrgbhAt(tmp, x, srcY+2)
 
-			c.R = lanczos2(c0.R, c1.R, c2.R, c3.R, dy)
-			c.G = lanczos2(c0.G, c1.G, c2.G, c3.G, dy)
-			c.B = lanczos2(c0.B, c1.B, c2.B, c3.B, dy)
-			c.A = lanczos2(c0.A, c1.A, c2.A, c3.A, dy)
+			a0 := cache[dy+1]
+			a1 := cache[dy+0]
+			a2 := cache[dy-1]
+			a3 := cache[dy-2]
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})
@@ -69,6 +95,27 @@ func Lanczos3(dst, src *fp16.NRGBAh) {
 
 	tmp := fp16.NewNRGBAh(image.Rect(0, 0, dstDx, srcDy))
 
+	// pre-calculate lanczos weights
+	cache := make(map[float64]float64, 6*(dstDx+dstDy))
+	for x := 0; x < dstDx; x++ {
+		_, dx := scale(x, srcDx, dstDx)
+		cache[dx+2] = lanczos(dx+2, 3)
+		cache[dx+1] = lanczos(dx+1, 3)
+		cache[dx+0] = lanczos(dx+0, 3)
+		cache[dx-1] = lanczos(dx-1, 3)
+		cache[dx-2] = lanczos(dx-2, 3)
+		cache[dx-3] = lanczos(dx-3, 3)
+	}
+	for y := 0; y < dstDy; y++ {
+		_, dy := scale(y, srcDy, dstDy)
+		cache[dy+2] = lanczos(dy+2, 3)
+		cache[dy+1] = lanczos(dy+1, 3)
+		cache[dy+0] = lanczos(dy+0, 3)
+		cache[dy-1] = lanczos(dy-1, 3)
+		cache[dy-2] = lanczos(dy-2, 3)
+		cache[dy-3] = lanczos(dy-3, 3)
+	}
+
 	// resize horizontally
 	parallels.Parallel(0, srcDy, func(y int) {
 		for x := 0; x < dstDx; x++ {
@@ -81,10 +128,17 @@ func Lanczos3(dst, src *fp16.NRGBAh) {
 			c4 := nrgbhAt(src, srcBounds.Min.X+srcX+2, srcBounds.Min.Y+y)
 			c5 := nrgbhAt(src, srcBounds.Min.X+srcX+3, srcBounds.Min.Y+y)
 
-			c.R = lanczos3(c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, dx)
-			c.G = lanczos3(c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, dx)
-			c.B = lanczos3(c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, dx)
-			c.A = lanczos3(c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, dx)
+			a0 := cache[dx+2]
+			a1 := cache[dx+1]
+			a2 := cache[dx+0]
+			a3 := cache[dx-1]
+			a4 := cache[dx-2]
+			a5 := cache[dx-3]
+
+			c.R = product6(a0, a1, a2, a3, a4, a5, c0.R, c1.R, c2.R, c3.R, c4.R, c5.R)
+			c.G = product6(a0, a1, a2, a3, a4, a5, c0.G, c1.G, c2.G, c3.G, c4.G, c5.G)
+			c.B = product6(a0, a1, a2, a3, a4, a5, c0.B, c1.B, c2.B, c3.B, c4.B, c5.B)
+			c.A = product6(a0, a1, a2, a3, a4, a5, c0.A, c1.A, c2.A, c3.A, c4.A, c5.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -101,10 +155,17 @@ func Lanczos3(dst, src *fp16.NRGBAh) {
 			c4 := nrgbhAt(tmp, x, srcY+2)
 			c5 := nrgbhAt(tmp, x, srcY+3)
 
-			c.R = lanczos3(c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, dy)
-			c.G = lanczos3(c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, dy)
-			c.B = lanczos3(c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, dy)
-			c.A = lanczos3(c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, dy)
+			a0 := cache[dy+2]
+			a1 := cache[dy+1]
+			a2 := cache[dy+0]
+			a3 := cache[dy-1]
+			a4 := cache[dy-2]
+			a5 := cache[dy-3]
+
+			c.R = product6(a0, a1, a2, a3, a4, a5, c0.R, c1.R, c2.R, c3.R, c4.R, c5.R)
+			c.G = product6(a0, a1, a2, a3, a4, a5, c0.G, c1.G, c2.G, c3.G, c4.G, c5.G)
+			c.B = product6(a0, a1, a2, a3, a4, a5, c0.B, c1.B, c2.B, c3.B, c4.B, c5.B)
+			c.A = product6(a0, a1, a2, a3, a4, a5, c0.A, c1.A, c2.A, c3.A, c4.A, c5.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})
@@ -121,6 +182,31 @@ func Lanczos4(dst, src *fp16.NRGBAh) {
 
 	tmp := fp16.NewNRGBAh(image.Rect(0, 0, dstDx, srcDy))
 
+	// pre-calculate lanczos weights
+	cache := make(map[float64]float64, 8*(dstDx+dstDy))
+	for x := 0; x < dstDx; x++ {
+		_, dx := scale(x, srcDx, dstDx)
+		cache[dx+3] = lanczos(dx+3, 4)
+		cache[dx+2] = lanczos(dx+2, 4)
+		cache[dx+1] = lanczos(dx+1, 4)
+		cache[dx+0] = lanczos(dx+0, 4)
+		cache[dx-1] = lanczos(dx-1, 4)
+		cache[dx-2] = lanczos(dx-2, 4)
+		cache[dx-3] = lanczos(dx-3, 4)
+		cache[dx-4] = lanczos(dx-4, 4)
+	}
+	for y := 0; y < dstDy; y++ {
+		_, dy := scale(y, srcDy, dstDy)
+		cache[dy+3] = lanczos(dy+3, 4)
+		cache[dy+2] = lanczos(dy+2, 4)
+		cache[dy+1] = lanczos(dy+1, 4)
+		cache[dy+0] = lanczos(dy+0, 4)
+		cache[dy-1] = lanczos(dy-1, 4)
+		cache[dy-2] = lanczos(dy-2, 4)
+		cache[dy-3] = lanczos(dy-3, 4)
+		cache[dy-4] = lanczos(dy-4, 4)
+	}
+
 	// resize horizontally
 	parallels.Parallel(0, srcDy, func(y int) {
 		for x := 0; x < dstDx; x++ {
@@ -135,10 +221,19 @@ func Lanczos4(dst, src *fp16.NRGBAh) {
 			c6 := nrgbhAt(src, srcBounds.Min.X+srcX+3, srcBounds.Min.Y+y)
 			c7 := nrgbhAt(src, srcBounds.Min.X+srcX+4, srcBounds.Min.Y+y)
 
-			c.R = lanczos4(c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, c6.R, c7.R, dx)
-			c.G = lanczos4(c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, c6.G, c7.G, dx)
-			c.B = lanczos4(c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, c6.B, c7.B, dx)
-			c.A = lanczos4(c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, c6.A, c7.A, dx)
+			a0 := cache[dx+3]
+			a1 := cache[dx+2]
+			a2 := cache[dx+1]
+			a3 := cache[dx+0]
+			a4 := cache[dx-1]
+			a5 := cache[dx-2]
+			a6 := cache[dx-3]
+			a7 := cache[dx-4]
+
+			c.R = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, c6.R, c7.R)
+			c.G = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, c6.G, c7.G)
+			c.B = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, c6.B, c7.B)
+			c.A = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, c6.A, c7.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -157,10 +252,19 @@ func Lanczos4(dst, src *fp16.NRGBAh) {
 			c6 := nrgbhAt(tmp, x, srcY+3)
 			c7 := nrgbhAt(tmp, x, srcY+4)
 
-			c.R = lanczos4(c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, c6.R, c7.R, dy)
-			c.G = lanczos4(c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, c6.G, c7.G, dy)
-			c.B = lanczos4(c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, c6.B, c7.B, dy)
-			c.A = lanczos4(c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, c6.A, c7.A, dy)
+			a0 := cache[dy+3]
+			a1 := cache[dy+2]
+			a2 := cache[dy+1]
+			a3 := cache[dy+0]
+			a4 := cache[dy-1]
+			a5 := cache[dy-2]
+			a6 := cache[dy-3]
+			a7 := cache[dy-4]
+
+			c.R = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.R, c1.R, c2.R, c3.R, c4.R, c5.R, c6.R, c7.R)
+			c.G = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.G, c1.G, c2.G, c3.G, c4.G, c5.G, c6.G, c7.G)
+			c.B = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.B, c1.B, c2.B, c3.B, c4.B, c5.B, c6.B, c7.B)
+			c.A = product8(a0, a1, a2, a3, a4, a5, a6, a7, c0.A, c1.A, c2.A, c3.A, c4.A, c5.A, c6.A, c7.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})
@@ -180,37 +284,4 @@ func lanczos(x, lobe float64) float64 {
 		return sinc(x) * sinc(x/lobe)
 	}
 	return 0
-}
-
-func lanczos2(c0, c1, c2, c3 float16.Float16, d float64) float16.Float16 {
-	var c float64
-	c = math.FMA(lanczos(d+1, 2), c0.Float64(), c)
-	c = math.FMA(lanczos(d+0, 2), c1.Float64(), c)
-	c = math.FMA(lanczos(d-1, 2), c2.Float64(), c)
-	c = math.FMA(lanczos(d-2, 2), c3.Float64(), c)
-	return float16.FromFloat64(c)
-}
-
-func lanczos3(c0, c1, c2, c3, c4, c5 float16.Float16, d float64) float16.Float16 {
-	var c float64
-	c = math.FMA(lanczos(d+2, 3), c0.Float64(), c)
-	c = math.FMA(lanczos(d+1, 3), c1.Float64(), c)
-	c = math.FMA(lanczos(d+0, 3), c2.Float64(), c)
-	c = math.FMA(lanczos(d-1, 3), c3.Float64(), c)
-	c = math.FMA(lanczos(d-2, 3), c4.Float64(), c)
-	c = math.FMA(lanczos(d-3, 3), c5.Float64(), c)
-	return float16.FromFloat64(c)
-}
-
-func lanczos4(c0, c1, c2, c3, c4, c5, c6, c7 float16.Float16, d float64) float16.Float16 {
-	var c float64
-	c = math.FMA(lanczos(d+3, 4), c0.Float64(), c)
-	c = math.FMA(lanczos(d+2, 4), c1.Float64(), c)
-	c = math.FMA(lanczos(d+1, 4), c2.Float64(), c)
-	c = math.FMA(lanczos(d+0, 4), c3.Float64(), c)
-	c = math.FMA(lanczos(d-1, 4), c4.Float64(), c)
-	c = math.FMA(lanczos(d-2, 4), c5.Float64(), c)
-	c = math.FMA(lanczos(d-3, 4), c6.Float64(), c)
-	c = math.FMA(lanczos(d-4, 4), c7.Float64(), c)
-	return float16.FromFloat64(c)
 }

--- a/resize/utils.go
+++ b/resize/utils.go
@@ -1,6 +1,9 @@
 package resize
 
 import (
+	"math"
+
+	"github.com/shogo82148/float16"
 	"github.com/shogo82148/go-imaging/fp16"
 	"github.com/shogo82148/go-imaging/fp16/fp16color"
 )
@@ -27,4 +30,40 @@ func nrgbhAt(img *fp16.NRGBAh, x, y int) fp16color.NRGBAh {
 	x = max(bounds.Min.X, min(bounds.Max.X-1, x))
 	y = max(bounds.Min.Y, min(bounds.Max.Y-1, y))
 	return img.NRGBAhAt(x, y)
+}
+
+// product4 calculates inner product of [a0, a1, a2, a3] and [c0, c1, c2, c3].
+func product4(a0, a1, a2, a3 float64, c0, c1, c2, c3 float16.Float16) float16.Float16 {
+	var c float64
+	c = math.FMA(a0, c0.Float64(), c)
+	c = math.FMA(a1, c1.Float64(), c)
+	c = math.FMA(a2, c2.Float64(), c)
+	c = math.FMA(a3, c3.Float64(), c)
+	return float16.FromFloat64(c)
+}
+
+// product6 calculates inner product of [a0, a1, a2, a3, a4, a5] and [c0, c1, c2, c3, c4, c5].
+func product6(a0, a1, a2, a3, a4, a5 float64, c0, c1, c2, c3, c4, c5 float16.Float16) float16.Float16 {
+	var c float64
+	c = math.FMA(a0, c0.Float64(), c)
+	c = math.FMA(a1, c1.Float64(), c)
+	c = math.FMA(a2, c2.Float64(), c)
+	c = math.FMA(a3, c3.Float64(), c)
+	c = math.FMA(a4, c4.Float64(), c)
+	c = math.FMA(a5, c5.Float64(), c)
+	return float16.FromFloat64(c)
+}
+
+// product8 calculates inner product of [a0, a1, a2, a3, a4, a5, a6, a7] and [c0, c1, c2, c3, c4, c5, c6, c7].
+func product8(a0, a1, a2, a3, a4, a5, a6, a7 float64, c0, c1, c2, c3, c4, c5, c6, c7 float16.Float16) float16.Float16 {
+	var c float64
+	c = math.FMA(a0, c0.Float64(), c)
+	c = math.FMA(a1, c1.Float64(), c)
+	c = math.FMA(a2, c2.Float64(), c)
+	c = math.FMA(a3, c3.Float64(), c)
+	c = math.FMA(a4, c4.Float64(), c)
+	c = math.FMA(a5, c5.Float64(), c)
+	c = math.FMA(a6, c6.Float64(), c)
+	c = math.FMA(a7, c7.Float64(), c)
+	return float16.FromFloat64(c)
 }


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-imaging/resize
                   │   .old.txt   │               .new.txt               │
                   │    sec/op    │    sec/op     vs base                │
BiLinear-10           2.473m ± 1%    2.485m ± 6%        ~ (p=0.075 n=10)
CatmullRom-10         4.166m ± 1%    4.221m ± 1%   +1.31% (p=0.015 n=10)
General-10            4.170m ± 1%    4.319m ± 3%   +3.57% (p=0.000 n=10)
Hermite-10            2.588m ± 1%    2.606m ± 1%   +0.71% (p=0.019 n=10)
Lanczos2-10          11.591m ± 2%    4.097m ± 2%  -64.65% (p=0.000 n=10)
Lanczos3-10          16.468m ± 1%    5.959m ± 2%  -63.81% (p=0.000 n=10)
Lanczos4-10          20.269m ± 1%    7.540m ± 1%  -62.80% (p=0.000 n=10)
Mitchell-10           4.300m ± 2%    4.208m ± 0%   -2.14% (p=0.000 n=10)
NearestNeighbor-10    586.6µ ± 4%    576.4µ ± 0%   -1.73% (p=0.000 n=10)
Scale/old-10         0.3180n ± 1%   0.3163n ± 0%   -0.52% (p=0.007 n=10)
Scale/new-10         0.3200n ± 1%   0.3164n ± 0%   -1.14% (p=0.000 n=10)
geomean               233.1µ         176.8µ       -24.15%
```