### PR TITLE
reduce calling cubicBC in Mitchell

### DIFF
--- a/resize/mitchell.go
+++ b/resize/mitchell.go
@@ -30,10 +30,15 @@ func Mitchell(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(src, srcBounds.Min.X+srcX+1, srcBounds.Min.Y+y)
 			c3 := nrgbhAt(src, srcBounds.Min.X+srcX+2, srcBounds.Min.Y+y)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dx, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dx, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dx, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dx, coeff)
+			a0 := cubicBC(dx+1, coeff)
+			a1 := cubicBC(dx+0, coeff)
+			a2 := cubicBC(dx-1, coeff)
+			a3 := cubicBC(dx-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -48,10 +53,15 @@ func Mitchell(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(tmp, x, srcY+1)
 			c3 := nrgbhAt(tmp, x, srcY+2)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dy, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dy, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dy, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dy, coeff)
+			a0 := cubicBC(dy+1, coeff)
+			a1 := cubicBC(dy+0, coeff)
+			a2 := cubicBC(dy-1, coeff)
+			a3 := cubicBC(dy-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-imaging/resize
            │  .old.txt   │              .new.txt               │
            │   sec/op    │   sec/op     vs base                │
Mitchell-10   4.257m ± 1%   3.068m ± 1%  -27.91% (p=0.000 n=10)
```