### PR TITLE
reduce calling cubicBC

### DIFF
--- a/resize/catmull_rom.go
+++ b/resize/catmull_rom.go
@@ -30,10 +30,15 @@ func CatmullRom(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(src, srcBounds.Min.X+srcX+1, srcBounds.Min.Y+y)
 			c3 := nrgbhAt(src, srcBounds.Min.X+srcX+2, srcBounds.Min.Y+y)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dx, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dx, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dx, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dx, coeff)
+			a0 := cubicBC(dx+1, coeff)
+			a1 := cubicBC(dx+0, coeff)
+			a2 := cubicBC(dx-1, coeff)
+			a3 := cubicBC(dx-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -48,10 +53,15 @@ func CatmullRom(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(tmp, x, srcY+1)
 			c3 := nrgbhAt(tmp, x, srcY+2)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dy, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dy, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dy, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dy, coeff)
+			a0 := cubicBC(dy+1, coeff)
+			a1 := cubicBC(dy+0, coeff)
+			a2 := cubicBC(dy-1, coeff)
+			a3 := cubicBC(dy-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})

--- a/resize/cubic.go
+++ b/resize/cubic.go
@@ -2,12 +2,10 @@ package resize
 
 import (
 	"math"
-
-	"github.com/shogo82148/float16"
 )
 
 // https://qiita.com/yoya/items/f167b2598fec98679422
-func cubicBCcoefficient(b, c float64) []float64 {
+func cubicBCcoefficient(b, c float64) [8]float64 {
 	p := 2 - 1.5*b - c
 	q := -3 + 2*b + c
 	r := 0.0
@@ -16,10 +14,10 @@ func cubicBCcoefficient(b, c float64) []float64 {
 	u := b + 5.0*c
 	v := -2*b - 8*c
 	w := (4.0/3)*b + 4*c
-	return []float64{p, q, r, s, t, u, v, w}
+	return [8]float64{p, q, r, s, t, u, v, w}
 }
 
-func cubicBC(x float64, coeff []float64) float64 {
+func cubicBC(x float64, coeff [8]float64) float64 {
 	var y float64
 	p, q, r, s, t, u, v, w := coeff[0], coeff[1], coeff[2], coeff[3], coeff[4], coeff[5], coeff[6], coeff[7]
 	x = math.Abs(x)
@@ -29,12 +27,4 @@ func cubicBC(x float64, coeff []float64) float64 {
 		y = ((t*x+u)*x+v)*x + w
 	}
 	return y
-}
-
-func general(c0, c1, c2, c3 float16.Float16, d float64, coeff []float64) float16.Float16 {
-	a0 := cubicBC(1+d, coeff)
-	a1 := cubicBC(d, coeff)
-	a2 := cubicBC(1-d, coeff)
-	a3 := cubicBC(2-d, coeff)
-	return float16.FromFloat64(c0.Float64()*a0 + c1.Float64()*a1 + c2.Float64()*a2 + c3.Float64()*a3)
 }

--- a/resize/general.go
+++ b/resize/general.go
@@ -30,10 +30,15 @@ func General(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(src, srcBounds.Min.X+srcX+1, srcBounds.Min.Y+y)
 			c3 := nrgbhAt(src, srcBounds.Min.X+srcX+2, srcBounds.Min.Y+y)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dx, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dx, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dx, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dx, coeff)
+			a0 := cubicBC(dx+1, coeff)
+			a1 := cubicBC(dx+0, coeff)
+			a2 := cubicBC(dx-1, coeff)
+			a3 := cubicBC(dx-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			tmp.SetNRGBAh(x, y, c)
 		}
 	})
@@ -48,10 +53,15 @@ func General(dst, src *fp16.NRGBAh) {
 			c2 := nrgbhAt(tmp, x, srcY+1)
 			c3 := nrgbhAt(tmp, x, srcY+2)
 
-			c.R = general(c0.R, c1.R, c2.R, c3.R, dy, coeff)
-			c.G = general(c0.G, c1.G, c2.G, c3.G, dy, coeff)
-			c.B = general(c0.B, c1.B, c2.B, c3.B, dy, coeff)
-			c.A = general(c0.A, c1.A, c2.A, c3.A, dy, coeff)
+			a0 := cubicBC(dy+1, coeff)
+			a1 := cubicBC(dy+0, coeff)
+			a2 := cubicBC(dy-1, coeff)
+			a3 := cubicBC(dy-2, coeff)
+
+			c.R = product4(a0, a1, a2, a3, c0.R, c1.R, c2.R, c3.R)
+			c.G = product4(a0, a1, a2, a3, c0.G, c1.G, c2.G, c3.G)
+			c.B = product4(a0, a1, a2, a3, c0.B, c1.B, c2.B, c3.B)
+			c.A = product4(a0, a1, a2, a3, c0.A, c1.A, c2.A, c3.A)
 			dst.SetNRGBAh(x+dstBounds.Min.X, y+dstBounds.Min.Y, c)
 		}
 	})


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-imaging/resize
                  │   .old.txt   │               .new.txt               │
                  │    sec/op    │    sec/op     vs base                │
BiLinear-8           3.277m ± 0%    3.265m ± 0%   -0.35% (p=0.015 n=10)
CatmullRom-8         5.537m ± 2%    4.010m ± 2%  -27.58% (p=0.000 n=10)
General-8            5.490m ± 6%    4.006m ± 1%  -27.02% (p=0.000 n=10)
Hermite-8            3.360m ± 2%    3.418m ± 0%   +1.73% (p=0.023 n=10)
Lanczos2-8           5.207m ± 4%    5.308m ± 1%   +1.94% (p=0.019 n=10)
Lanczos3-8           7.580m ± 1%    7.594m ± 1%        ~ (p=0.218 n=10)
Lanczos4-8           9.835m ± 2%    9.894m ± 4%        ~ (p=0.280 n=10)
Mitchell-8           4.044m ± 1%    4.006m ± 0%   -0.94% (p=0.002 n=10)
NearestNeighbor-8    721.5µ ± 0%    724.2µ ± 4%   +0.36% (p=0.019 n=10)
Scale/old-8         0.3207n ± 0%   0.3202n ± 0%        ~ (p=0.148 n=10)
Scale/new-8         0.3205n ± 0%   0.3201n ± 0%   -0.12% (p=0.041 n=10)
geomean              212.0µ         200.7µ        -5.36%
```